### PR TITLE
Update oidc.conf

### DIFF
--- a/apache_skeleton/oidc.conf
+++ b/apache_skeleton/oidc.conf
@@ -1,6 +1,7 @@
 Listen 8090
 LogLevel debug
-ServerName localhost
+# ServerName localhost
+ServerName yourtesthost
 
 LoadModule auth_openidc_module /usr/lib/apache2/modules/mod_auth_openidc.so
 LoadModule ssl_module /usr/lib/apache2/modules/mod_ssl.so
@@ -10,10 +11,11 @@ LoadModule cgi_module /usr/lib/apache2/modules/mod_cgi.so
 OIDCMetadataDir /var/lib/apache2/mod_auth_openidc
 
 OIDCCryptoPassphrase py7h0n_rul35!
-OIDCRedirectURI https://localhost:8090/protected/redirect_uri
+OIDCRedirectURI https://yourtesthost:8090/protected/redirect_uri
 
 # IMPLICIT FLOW
 # OIDCResponseType "id_token token"
+# OIDCRedirectURI https://yourtesthost:8090/protected/implicit_flow_callback
 
 # HYBRID FLOW
 # OIDCResponseType "code id_token"


### PR DESCRIPTION
As per the FUNET guys, a webflow with implicit_flow_callback *may not* be 'localhost'. It should be an actual hostname or IP address. In the spec apparently...